### PR TITLE
Escape regular text

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "driebit/elm-ginger",
     "summary": "Ginger CMS integration",
     "license": "BSD-3-Clause",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "exposed-modules": [
         "Ginger.Resource",
         "Ginger.Resource.Extra",

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -122,7 +122,7 @@ toIso639 language =
 
 We try to unescape the escaped characters but if that fails we'll render the `Translation` as is.
 
-Html elements will be filtered out and the text will be joined with a space char
+Html elements will be filtered out and the text will be joined.
 
 -}
 text : Language -> Translation -> Html msg

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -136,7 +136,7 @@ text_ s =
         textNodes n acc =
             case n of
                 Html.Parser.Text t ->
-                    t ++ " " ++ acc
+                    t ++ acc
 
                 Html.Parser.Element _ _ n_ ->
                     List.foldr textNodes acc n_

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -122,7 +122,7 @@ toIso639 language =
 
 We try to unescape the escaped characters but if that fails we'll render the `Translation` as is.
 
-Html elements will be filtered out and the text will be joined with newlines.
+Html elements will be filtered out and the text will be joined with a space char
 
 -}
 text : Language -> Translation -> Html msg
@@ -136,29 +136,24 @@ text_ s =
         textNodes n acc =
             case n of
                 Html.Parser.Text t ->
-                    t :: acc
+                    t ++ " " ++ acc
+
+                Html.Parser.Element _ _ n_ ->
+                    List.foldr textNodes acc n_
 
                 _ ->
                     acc
 
         parsedString =
-            Result.map Html.Parser.Util.toVirtualDom <|
-                Result.map (List.singleton << Html.Parser.Text << String.join "\n") <|
-                    Result.map (List.foldr textNodes []) <|
-                        Html.Parser.run s
+            Result.map (List.foldr textNodes "") <|
+                Html.Parser.run s
     in
     case parsedString of
         Err _ ->
             Html.text s
 
-        Ok [] ->
-            Html.text ""
-
-        {- Because we construct the List ourselves it's impossible
-           to have more than one element in the List
-        -}
-        Ok (ok :: _) ->
-            ok
+        Ok t ->
+            Html.text t
 
 
 {-| Translate and render as Html markup

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -42,7 +42,12 @@ suite =
             \_ ->
                 Html.article [] [ Translation.text NL escapedTranslation ]
                     |> Query.fromHtml
-                    |> Query.has [ text "\"Hallo\"" ]
+                    |> Query.has [ text "\"Hallo\" \"wereld\"" ]
+        , test "Renders a translated text as html unescapes chars and removes nodes" <|
+            \_ ->
+                Html.article [] [ Translation.text NL escapedHtmlTranslation ]
+                    |> Query.fromHtml
+                    |> Query.has [ text "\"Hallo\" \"wereld\"" ]
         , test "Renders a translated html as html" <|
             \_ ->
                 Html.article [] [ Translation.html NL htmlTranslation ]
@@ -81,7 +86,14 @@ htmlTranslation =
 escapedTranslation : Translation
 escapedTranslation =
     Translation.fromList
-        [ ( NL, "&quot;Hallo&quot;" )
+        [ ( NL, "&quot;Hallo&quot; &quot;wereld&quot;" )
+        ]
+
+
+escapedHtmlTranslation : Translation
+escapedHtmlTranslation =
+    Translation.fromList
+        [ ( NL, "<i>&quot;Hallo&quot;</i><b>&quot;wereld&quot;</b>" )
         ]
 
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -38,6 +38,11 @@ suite =
                 Html.article [] [ Translation.text NL translation ]
                     |> Query.fromHtml
                     |> Query.has [ text "Hallo" ]
+        , test "Renders a translated text as html and unescapes chars" <|
+            \_ ->
+                Html.article [] [ Translation.text NL escapedTranslation ]
+                    |> Query.fromHtml
+                    |> Query.has [ text "\"Hallo\"" ]
         , test "Renders a translated html as html" <|
             \_ ->
                 Html.article [] [ Translation.html NL htmlTranslation ]
@@ -70,6 +75,13 @@ htmlTranslation : Translation
 htmlTranslation =
     Translation.fromList
         [ ( NL, "<p>Hallo</p>" )
+        ]
+
+
+escapedTranslation : Translation
+escapedTranslation =
+    Translation.fromList
+        [ ( NL, "&quot;Hallo&quot;" )
         ]
 
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -53,6 +53,11 @@ suite =
                 Html.article [] [ Translation.text NL escapedHtmlTranslationWithSpace ]
                     |> Query.fromHtml
                     |> Query.has [ text "\"Hallo\" \"wereld\"" ]
+        , test "Renders a translated text as html, preserves unescaped chars" <|
+            \_ ->
+                Html.article [] [ Translation.text NL unescapedHtmlTranslation ]
+                    |> Query.fromHtml
+                    |> Query.has [ text "10 < 100 && 100 < 1000" ]
         , test "Renders a translated html as html" <|
             \_ ->
                 Html.article [] [ Translation.html NL htmlTranslation ]
@@ -106,6 +111,13 @@ escapedHtmlTranslationWithSpace : Translation
 escapedHtmlTranslationWithSpace =
     Translation.fromList
         [ ( NL, "<i>&quot;Hallo&quot;</i> <b>&quot;wereld&quot;</b>" )
+        ]
+
+
+unescapedHtmlTranslation : Translation
+unescapedHtmlTranslation =
+    Translation.fromList
+        [ ( NL, "10 < 100 && 100 < 1000" )
         ]
 
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -43,11 +43,16 @@ suite =
                 Html.article [] [ Translation.text NL escapedTranslation ]
                     |> Query.fromHtml
                     |> Query.has [ text "\"Hallo\" \"wereld\"" ]
-        , test "Renders a translated text as html unescapes chars and removes nodes" <|
+        , test "Renders a translated text as html, unescapes chars and removes nodes" <|
             \_ ->
                 Html.article [] [ Translation.text NL escapedHtmlTranslation ]
                     |> Query.fromHtml
                     |> Query.has [ text "\"Hallo\"\"wereld\"" ]
+        , test "Renders a translated text as html, unescapes chars, remove nodes and preserves spaces" <|
+            \_ ->
+                Html.article [] [ Translation.text NL escapedHtmlTranslationWithSpace ]
+                    |> Query.fromHtml
+                    |> Query.has [ text "\"Hallo\" \"wereld\"" ]
         , test "Renders a translated html as html" <|
             \_ ->
                 Html.article [] [ Translation.html NL htmlTranslation ]
@@ -94,6 +99,13 @@ escapedHtmlTranslation : Translation
 escapedHtmlTranslation =
     Translation.fromList
         [ ( NL, "<i>&quot;Hallo&quot;</i><b>&quot;wereld&quot;</b>" )
+        ]
+
+
+escapedHtmlTranslationWithSpace : Translation
+escapedHtmlTranslationWithSpace =
+    Translation.fromList
+        [ ( NL, "<i>&quot;Hallo&quot;</i> <b>&quot;wereld&quot;</b>" )
         ]
 
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -47,7 +47,7 @@ suite =
             \_ ->
                 Html.article [] [ Translation.text NL escapedHtmlTranslation ]
                     |> Query.fromHtml
-                    |> Query.has [ text "\"Hallo\" \"wereld\"" ]
+                    |> Query.has [ text "\"Hallo\"\"wereld\"" ]
         , test "Renders a translated html as html" <|
             \_ ->
                 Html.article [] [ Translation.html NL htmlTranslation ]


### PR DESCRIPTION
Makes sure text like `&quot;Hallo&quot;` gets render as `"Hallo"`.

Because we have to parse the string in order to escape the chars we'll also filter out all html elements and join the resulting strings. It's a bit implicit... but also convenient, opinions? It's doesn't change the expected behaviour, or at least not in a way we use it now. 