### PR TITLE
Translation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v2.2.0
+*  Escape `Translation.toString` and add `toStringEscaped` to access the original String
+
 # v2.1.0
 * Add `Ginger.Util` containing Html parsing and conditional view rendering functions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 # v2.2.0
-*  Escape `Translation.toString` and add `toStringEscaped` to access the original String
+* Escape `Translation.toString`,
+* Add `toStringEscaped` to access the original String
+* Add `isEmpty` to check if a translation is an empty String
 
 # v2.1.0
 * Add `Ginger.Util` containing Html parsing and conditional view rendering functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # v2.2.0
-* Escape `Translation.toString`,
+* Unescape `Translation.toString`,
 * Add `toStringEscaped` to access the original String
 * Add `isEmpty` to check if a translation is an empty String
 

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "driebit/elm-ginger",
     "summary": "Ginger CMS integration",
     "license": "BSD-3-Clause",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "exposed-modules": [
         "Ginger.Resource",
         "Ginger.Resource.Extra",

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -2,6 +2,7 @@ module Ginger.Translation exposing
     ( Translation
     , Language(..)
     , toString
+    , toStringEscaped
     , withDefault
     , fromList
     , toIso639
@@ -22,6 +23,7 @@ module Ginger.Translation exposing
 # Conversion
 
 @docs toString
+@docs toStringEscaped
 @docs withDefault
 @docs fromList
 @docs toIso639
@@ -103,11 +105,21 @@ languageModifier language =
 
 {-| Get the translated String value.
 
-_Defaults to an empty String._
+_Unescapes character entity references, strips Html nodes and defaults to an empty String._
 
 -}
 toString : Language -> Translation -> String
 toString language (Translation translation) =
+    Internal.Html.stripHtml (languageAccessor language translation)
+
+
+{-| Get the _original_ translated String value as returned by the REST api.
+
+_Defaults to an empty String._
+
+-}
+toStringEscaped : Language -> Translation -> String
+toStringEscaped language (Translation translation) =
     languageAccessor language translation
 
 
@@ -126,6 +138,13 @@ withDefault def language (Translation translation) =
 
         lang ->
             lang
+
+
+{-| Checks if translated String is empty.
+-}
+isEmpty : Language -> Translation -> Bool
+isEmpty language (Translation translation) =
+    String.isEmpty (languageAccessor language translation)
 
 
 {-| Construct a Translation from a list of Language and String value pairs
@@ -166,14 +185,14 @@ Html elements will be filtered out and the text will be joined.
 -}
 text : Language -> Translation -> Html msg
 text language translation =
-    Html.text (Internal.Html.stripHtml (toString language translation))
+    Html.text (toString language translation)
 
 
 {-| Translate and render as Html markup
 -}
 html : Language -> Translation -> List (Html msg)
 html language translation =
-    Internal.Html.toHtml (toString language translation)
+    Internal.Html.toHtml (toStringEscaped language translation)
 
 
 

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -4,6 +4,7 @@ module Ginger.Translation exposing
     , toString
     , toStringEscaped
     , withDefault
+    , isEmpty
     , fromList
     , toIso639
     , text
@@ -25,6 +26,7 @@ module Ginger.Translation exposing
 @docs toString
 @docs toStringEscaped
 @docs withDefault
+@docs isEmpty
 @docs fromList
 @docs toIso639
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -17,6 +17,18 @@ suite =
             \_ ->
                 Expect.equal "Hello" <|
                     Translation.toString EN translation
+        , test "Returns a translated string and unescapes chars" <|
+            \_ ->
+                Expect.equal "\"Hello\"" <|
+                    Translation.toString EN translationEscaped
+        , test "Returns a translated string and removes html nodes" <|
+            \_ ->
+                Expect.equal "Hallo" <|
+                    Translation.toString NL htmlTranslation
+        , test "Returns the orginal translated string" <|
+            \_ ->
+                Expect.equal "<p>Hallo</p>" <|
+                    Translation.toStringEscaped NL htmlTranslation
         , test "Returns an fallback string" <|
             \_ ->
                 Expect.equal "Hallo" <|
@@ -52,6 +64,13 @@ translation =
     Translation.fromList
         [ ( NL, "Hallo" )
         , ( EN, "Hello" )
+        ]
+
+
+translationEscaped : Translation
+translationEscaped =
+    Translation.fromList
+        [ ( EN, "&quot;Hello&quot;" )
         ]
 
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -56,6 +56,14 @@ suite =
                     |> Query.fromHtml
                     |> Query.find [ tag "p" ]
                     |> Query.has [ text "Hallo" ]
+        , test "Is empty Translation" <|
+            \_ ->
+                Expect.true "Expected the String to be empty" <|
+                    Translation.isEmpty NL (Translation.fromList [])
+        , test "Is not empty Translation" <|
+            \_ ->
+                Expect.false "Expected the String to not be empty" <|
+                    Translation.isEmpty NL translation
         ]
 
 


### PR DESCRIPTION
* Escape `Translation.toString`,
* Add `toStringEscaped` to access the original String
* Add `isEmpty` to check if a translation is an empty String