### PR TITLE
3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v2.3.0
+* Add `Ginger.Menu`
+* Add `Translation.empty`
+
 # v2.2.1
 * Unescape `Translation.withDefault`,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v3.0.0
+* Rename edgesWithPredicate -> objectsOfPredicate
+* Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` from `ResourceWith Edges`)
+
 # v2.3.0
 * Add Id.toJson
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 # v3.0.0
+* Add `Resource` alias for ResourceWith Edges
+* Add `Translation.DE`
 * Add `Ginger.Menu`
 * Add `Translation.empty`
 * Add `Translation.textNL`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 # v3.0.0
 * Rename edgesWithPredicate -> objectsOfPredicate
 * Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` from `ResourceWith Edges`)
-* Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead.
+* Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead
+* Add `unescape`
 
 # v2.3.0
 * Add Id.toJson
 
 # v2.2.1
-* Unescape `Translation.withDefault`,
+* Unescape `Translation.withDefault`
 
 # v2.2.0
 * Unescape `Translation.toString`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # v3.0.0
 * Rename edgesWithPredicate -> objectsOfPredicate
 * Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` from `ResourceWith Edges`)
+* Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead.
 
 # v2.3.0
 * Add Id.toJson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 # v3.0.0
+* Rename `category` -> `getCategory`
+* Rename `depiction` -> `getDepiction`
+* Rename `depictions` -> `getDepictions`
+* Rename `category` -> `getCategory`
+* Rename `resourceQuery` -> `search`
+* Rename `locationQuery` -> `searchLocation`
+* Add common REST API request
+  * `deleteResource`
+  * `postEdge`
+  * `deleteEdge`
+  * `uploadFile`
+  * `uploadFileAndPostEdge`
+* Add `Request.HasContentGroup`
+* Add `Request.SearchType`
 * Add `Resource` alias for ResourceWith Edges
 * Add `Translation.DE`
 * Add `Ginger.Menu`
@@ -10,8 +24,6 @@
 * Add `Translation.textEN`
 * Add `Translation.htmlEN`
 * Add `Id.toJson`
-* Add `Request.HasContentGroup`
-* Add `Request.SearchType`
 * Rename edgesWithPredicate -> objectsOfPredicate
 * Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` instead of `ResourceWith Edges`)
 * Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 * Rename `category` -> `getCategory`
 * Rename `depiction` -> `getDepiction`
 * Rename `depictions` -> `getDepictions`
-* Rename `category` -> `getCategory`
 * Rename `resourceQuery` -> `search`
 * Rename `locationQuery` -> `searchLocation`
+* Rename `Results` -> `SearchResult`
 * Add common REST API request
   * `deleteResource`
   * `postEdge`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Add `Id.toJson`
 * Rename edgesWithPredicate -> objectsOfPredicate
 * Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` instead of `ResourceWith Edges`)
-* Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead
+* Deprecate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead
 
 # v2.2.1
 * Unescape `Translation.withDefault`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
 # v3.0.0
-* Add `unescape`
 * Add `Ginger.Menu`
 * Add `Translation.empty`
+* Add `Translation.textNL`
+* Add `Translation.htmlNL`
+* Add `Translation.textEN`
+* Add `Translation.htmlEN`
 * Add `Id.toJson`
+* Add `Request.HasContentGroup`
+* Add `Request.SearchType`
 * Rename edgesWithPredicate -> objectsOfPredicate
 * Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` from `ResourceWith Edges`)
 * Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add `Request.HasContentGroup`
 * Add `Request.SearchType`
 * Rename edgesWithPredicate -> objectsOfPredicate
-* Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` from `ResourceWith Edges`)
+* Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` instead of `ResourceWith Edges`)
 * Depricate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead
 
 # v2.2.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Driebit
+Copyright 2020 Driebit
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Driebit
+Copyright 2019 Driebit
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Create Elm websites backed by the [Ginger CMS](https://github.com/driebit/ginger
 
 **Ginger.Media**: Container for images attached to a resource.
 
+**Ginger.Menu**: Use Ginger main and footer menus
+
 **Ginger.Request**: Get and search resources.
 
 **Ginger.Util**: Functions for parsing and rendering `Html`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create Elm websites backed by the [Ginger CMS](https://github.com/driebit/ginger
 
 **Ginger.Media**: Container for images attached to a resource.
 
-**Ginger.Menu**: Use Ginger main and footer menus
+**Ginger.Menu**: Use or decode Ginger main and footer menus
 
 **Ginger.Request**: Get and search resources.
 

--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
         "Ginger.Predicate",
         "Ginger.Translation",
         "Ginger.Media",
+        "Ginger.Menu",
         "Ginger.Request",
         "Ginger.Util"
     ],

--- a/elm.json
+++ b/elm.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "NoRedInk/elm-json-decode-pipeline": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
+        "elm/file": "1.0.5 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/http": "2.0.0 <= v < 3.0.0",
         "elm/json": "1.1.3 <= v < 2.0.0",

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "driebit/elm-ginger",
     "summary": "Ginger CMS integration",
     "license": "BSD-3-Clause",
-    "version": "2.3.0",
+    "version": "3.0.0",
     "exposed-modules": [
         "Ginger.Resource",
         "Ginger.Resource.Extra",

--- a/src/Ginger/Menu.elm
+++ b/src/Ginger/Menu.elm
@@ -5,6 +5,9 @@ module Ginger.Menu exposing
     , empty
     , fromValue
     , fromJson
+    , decodeMenuItems
+    , decodeMenuItem
+    , decodeFooter
     )
 
 {-|
@@ -26,6 +29,9 @@ module Ginger.Menu exposing
 
 @docs fromValue
 @docs fromJson
+@docs decodeMenuItems
+@docs decodeMenuItem
+@docs decodeFooter
 
 -}
 
@@ -109,17 +115,42 @@ fromJson =
         |> Pipeline.required "footer_menu" decodeFooter
 
 
-decodeFooter : Decoder Footer
-decodeFooter =
-    Decode.succeed Footer
-        |> Pipeline.optional "subtitle" Translation.fromJson Translation.empty
-        |> Pipeline.optional "summary" Translation.fromJson Translation.empty
-        |> Pipeline.required "items" (Decode.list decodeMenuItem)
+{-| Build a custom menu `Decoder` re-using the decoders used in this module
+
+    type alias Menu =
+        { main : List Item
+        , mainExtra : List Item
+        , footer : List Item
+        , footerExtra : List Item
+        }
+
+    customFromJson : Decoder Menu
+    customFromJson =
+        Decode.succeed Menu
+            |> Pipeline.required "main_menu" decodeMenuItems
+            |> Pipeline.required "main_menu_extra" decodeMenuItems
+            |> Pipeline.required "footer_menu" decodeMenuItems
+            |> Pipeline.required "footer_menu_extra" decodeMenuItems
+
+-}
+decodeMenuItems : Decoder (List Item)
+decodeMenuItems =
+    Decode.list decodeMenuItem
 
 
+{-| -}
 decodeMenuItem : Decoder Item
 decodeMenuItem =
     Decode.succeed Item
         |> Pipeline.required "id" Id.fromJson
         |> Pipeline.required "title" Translation.fromJson
         |> Pipeline.optional "page_url" Decode.string ""
+
+
+{-| -}
+decodeFooter : Decoder Footer
+decodeFooter =
+    Decode.succeed Footer
+        |> Pipeline.optional "subtitle" Translation.fromJson Translation.empty
+        |> Pipeline.optional "summary" Translation.fromJson Translation.empty
+        |> Pipeline.required "items" (Decode.list decodeMenuItem)

--- a/src/Ginger/Menu.elm
+++ b/src/Ginger/Menu.elm
@@ -1,0 +1,125 @@
+module Ginger.Menu exposing
+    ( Menu
+    , Item
+    , Footer
+    , empty
+    , fromValue
+    , fromJson
+    )
+
+{-|
+
+
+# Definitions
+
+@docs Menu
+@docs Item
+@docs Footer
+
+
+# Construct
+
+@docs empty
+
+
+# Decode
+
+@docs fromValue
+@docs fromJson
+
+-}
+
+import Ginger.Id as Id exposing (ResourceId)
+import Ginger.Translation as Translation exposing (Translation)
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as Pipeline
+
+
+
+-- DEFINITIONS
+
+
+{-| -}
+type alias Menu =
+    { main : List Item
+    , footer : Footer
+    }
+
+
+{-| -}
+type alias Footer =
+    { title : Translation
+    , summary : Translation
+    , items : List Item
+    }
+
+
+{-| -}
+type alias Item =
+    { id : ResourceId
+    , title : Translation
+    , path : String
+    }
+
+
+
+-- CONSTRUCTION
+
+
+{-| A `Menu` containing no values
+-}
+empty : Menu
+empty =
+    { main = []
+    , footer = Footer Translation.empty Translation.empty []
+    }
+
+
+{-| Decode a `Menu` from a `Decode.Value`, defaults to an empty `Menu`
+
+You can for example pass the menu as a flag and initialize you app like:
+
+    main : Program Decode.Value Model Msg
+    main =
+        Browser.application
+            { init = init << Ginger.Menu.fromValue
+            , view = view
+            , update = update
+            , subscriptions = subscriptions
+            , onUrlChange = OnUrlChange
+            , onUrlRequest = OnUrlRequest
+            }
+
+-}
+fromValue : Decode.Value -> Menu
+fromValue =
+    Decode.decodeValue fromJson
+        >> Result.withDefault empty
+
+
+
+-- DECODE
+
+
+{-| -}
+fromJson : Decoder Menu
+fromJson =
+    Decode.succeed Menu
+        |> Pipeline.required "main_menu" (Decode.list decodeMenuItem)
+        |> Pipeline.required "footer_menu" decodeFooter
+
+
+decodeFooter : Decoder Footer
+decodeFooter =
+    Decode.succeed Footer
+        |> Pipeline.optional "subtitle" Translation.fromJson Translation.empty
+        |> Pipeline.optional "summary" Translation.fromJson Translation.empty
+        |> Pipeline.required "items" (Decode.list decodeMenuItem)
+
+
+decodeMenuItem : Decoder Item
+decodeMenuItem =
+    Decode.succeed Item
+        |> Pipeline.required "id" Id.fromJson
+        |> Pipeline.required "title" Translation.fromJson
+        |> Pipeline.optional "page_url" Decode.string ""

--- a/src/Ginger/Request.elm
+++ b/src/Ginger/Request.elm
@@ -142,9 +142,9 @@ resourceByName msg id =
 
 {-|
 
-    request : Http.Request Http.Error (List Resource)
-    request =
-        Request.resourceQuery [ Text "amsterdam" ]
+    request : (Http.Request Http.Error Resource -> msg) -> Cmd msg
+    request toMsg =
+        Request.resourceQuery toMsg [ Text "amsterdam" ]
 
 -}
 resourceQuery :
@@ -182,7 +182,8 @@ locationQuery msg queryParams =
 {-| Some of these params only work if `mod_elasticsearch` is enabled
 -}
 type QueryParam
-    = ExcludeCategory Category
+    = HasContentGroup String
+    | ExcludeCategory Category
     | Facet String
     | Filter String Operator String
     | HasCategory Category
@@ -197,6 +198,7 @@ type QueryParam
     | PromoteCategory Category
     | SortBy SortField Ordering
     | Text String
+    | SearchType String
     | Custom String String
 
 
@@ -233,6 +235,9 @@ queryParamsToBuilder =
 toUrlParam : QueryParam -> Url.Builder.QueryParameter
 toUrlParam queryParam =
     case queryParam of
+        HasContentGroup group ->
+            Url.Builder.string "content_group" group
+
         HasCategory cat ->
             Url.Builder.string "cat" (Category.toString cat)
 
@@ -269,6 +274,9 @@ toUrlParam queryParam =
 
         Text text ->
             Url.Builder.string "text" text
+
+        SearchType type_ ->
+            Url.Builder.string "type" type_
 
         SortBy PublicationDate Asc ->
             Url.Builder.string "sort" "rsc.publication_start"

--- a/src/Ginger/Request.elm
+++ b/src/Ginger/Request.elm
@@ -9,7 +9,7 @@ module Ginger.Request exposing
     , uploadFileAndPostEdge
     , search
     , searchLocation
-    , Results
+    , SearchResult
     , QueryParam(..)
     , Ordering(..)
     , SortField(..)
@@ -49,7 +49,7 @@ module Ginger.Request exposing
 @docs search
 @docs searchLocation
 
-@docs Results
+@docs SearchResult
 
 @docs QueryParam
 @docs Ordering
@@ -81,7 +81,7 @@ import Url.Builder
 
 
 {-| -}
-type alias Results a =
+type alias SearchResult a =
     { results : List a
     , facets : Decode.Value
     , total : Int
@@ -102,9 +102,6 @@ absolute path queryParams =
 
 
 {-| Request a resource by `ResourceId`
-
-    Request.resourceById GotResource id
-
 -}
 resourceById : (Result Http.Error (ResourceWith Edges) -> msg) -> ResourceId -> Cmd msg
 resourceById msg id =
@@ -115,9 +112,6 @@ resourceById msg id =
 
 
 {-| Request a resource by its `page_path`
-
-    Request.resourceByPath GotResource "/news"
-
 -}
 resourceByPath : (Result Http.Error (ResourceWith Edges) -> msg) -> String -> Cmd msg
 resourceByPath msg path =
@@ -127,10 +121,7 @@ resourceByPath msg path =
         }
 
 
-{-| Request a resource by its uniquename
-
-    Request.resourceByName GotResource "home"
-
+{-| Request a resource by its unique name
 -}
 resourceByName : (Result Http.Error (ResourceWith Edges) -> msg) -> String -> Cmd msg
 resourceByName msg id =
@@ -150,7 +141,7 @@ resourceByName msg id =
 
 -}
 search :
-    (Result Http.Error (Results (ResourceWith Edges)) -> msg)
+    (Result Http.Error (SearchResult (ResourceWith Edges)) -> msg)
     -> List QueryParam
     -> Cmd msg
 search msg queryParams =
@@ -170,7 +161,7 @@ search msg queryParams =
         [ Request.HasCategory Person ]
 
 -}
-searchLocation : (Result Http.Error (Results Location) -> msg) -> List QueryParam -> Cmd msg
+searchLocation : (Result Http.Error (SearchResult Location) -> msg) -> List QueryParam -> Cmd msg
 searchLocation msg queryParams =
     Http.get
         { url =
@@ -187,9 +178,6 @@ searchLocation msg queryParams =
 
 
 {-| Delete a resource by `ResourceId`
-
-    Request.deleteResource GotDeleteResource id
-
 -}
 deleteResource :
     (Result Http.Error () -> msg)
@@ -441,9 +429,9 @@ operatorToString operator =
 -- DECODE
 
 
-fromJson : Decode.Decoder (List a) -> Decode.Decoder (Results a)
+fromJson : Decode.Decoder (List a) -> Decode.Decoder (SearchResult a)
 fromJson decoder =
-    Decode.succeed Results
+    Decode.succeed SearchResult
         |> Pipeline.required "result" decoder
         |> Pipeline.required "facets" Decode.value
         |> Pipeline.required "total" Decode.int

--- a/src/Ginger/Resource.elm
+++ b/src/Ginger/Resource.elm
@@ -122,6 +122,12 @@ type alias Edge =
     }
 
 
+{-| Alias for `ResourceWith Edges`
+-}
+type alias Resource =
+    ResourceWith Edges
+
+
 {-| -}
 type alias Block =
     { body : Translation

--- a/src/Ginger/Resource.elm
+++ b/src/Ginger/Resource.elm
@@ -2,11 +2,12 @@ module Ginger.Resource exposing
     ( ResourceWith
     , Edges
     , Edge
+    , Resource
     , Block
     , BlockType(..)
-    , category
-    , depiction
-    , depictions
+    , getCategory
+    , getDepiction
+    , getDepictions
     , objectsOfPredicate
     , fromJsonWithEdges
     , fromJsonWithoutEdges
@@ -21,15 +22,16 @@ module Ginger.Resource exposing
 
 @docs Edges
 @docs Edge
+@docs Resource
 @docs Block
 @docs BlockType
 
 
 # Access data
 
-@docs category
-@docs depiction
-@docs depictions
+@docs getCategory
+@docs getDepiction
+@docs getDepictions
 @docs objectsOfPredicate
 
 
@@ -162,7 +164,7 @@ objectsOfPredicate predicate resource =
         List.filter ((==) predicate << .predicate) resource.edges
 
 
-{-| The category of a `ResourceWith`.
+{-| Get the category of a `ResourceWith`.
 
 Every resource has _one_ category, but can be part of a hierarchy of other
 categories. For example `news` is part of `text > article > news`. This function
@@ -172,8 +174,8 @@ _Note: there hasn't been the need to expose any of the parent categories so far,
 if there is please file an issue._
 
 -}
-category : ResourceWith a -> Category
-category =
+getCategory : ResourceWith a -> Category
+getCategory =
     List.NonEmpty.head << .category
 
 
@@ -182,9 +184,9 @@ category =
 Returns the image url if there is a depiction _and_ the mediaclass exists.
 
 -}
-depiction : Media.MediaClass -> ResourceWith Edges -> Maybe String
-depiction mediaClass =
-    List.head << depictions mediaClass
+getDepiction : Media.MediaClass -> ResourceWith Edges -> Maybe String
+getDepiction mediaClass =
+    List.head << getDepictions mediaClass
 
 
 {-| The image urls of the `ResourceWith` depictions
@@ -192,8 +194,8 @@ depiction mediaClass =
 Returns a list of image urls if there is a depiction _and_ the mediaclass exists.
 
 -}
-depictions : Media.MediaClass -> ResourceWith Edges -> List String
-depictions mediaClass resource =
+getDepictions : Media.MediaClass -> ResourceWith Edges -> List String
+getDepictions mediaClass resource =
     List.filterMap (Media.imageUrl mediaClass << .media) <|
         objectsOfPredicate Predicate.HasDepiction resource
 

--- a/src/Ginger/Resource.elm
+++ b/src/Ginger/Resource.elm
@@ -7,7 +7,7 @@ module Ginger.Resource exposing
     , category
     , depiction
     , depictions
-    , edgesWithPredicate
+    , objectsOfPredicate
     , fromJsonWithEdges
     , fromJsonWithoutEdges
     )
@@ -17,6 +17,7 @@ module Ginger.Resource exposing
 
 # Definitions
 
+@docs Resource
 @docs ResourceWith
 
 @docs Edges
@@ -30,7 +31,7 @@ module Ginger.Resource exposing
 @docs category
 @docs depiction
 @docs depictions
-@docs edgesWithPredicate
+@docs objectsOfPredicate
 
 
 # Decode
@@ -144,14 +145,14 @@ type BlockType
 -- QUERY
 
 
-{-| Return all edges with a given predicate.
+{-| Return all resources with a given predicate.
 
 The returned resources won't have any edges themselves, indicated by the `{}`
 in `ResourceWith {}`.
 
 -}
-edgesWithPredicate : Predicate -> ResourceWith Edges -> List (ResourceWith {})
-edgesWithPredicate predicate resource =
+objectsOfPredicate : Predicate -> { a | edges : List Edge } -> List (ResourceWith {})
+objectsOfPredicate predicate resource =
     List.map .resource <|
         List.filter ((==) predicate << .predicate) resource.edges
 
@@ -189,7 +190,7 @@ Returns a list of image urls if there is a depiction _and_ the mediaclass exists
 depictions : Media.MediaClass -> ResourceWith Edges -> List String
 depictions mediaClass resource =
     List.filterMap (Media.imageUrl mediaClass << .media) <|
-        edgesWithPredicate Predicate.HasDepiction resource
+        objectsOfPredicate Predicate.HasDepiction resource
 
 
 

--- a/src/Ginger/Resource.elm
+++ b/src/Ginger/Resource.elm
@@ -17,7 +17,6 @@ module Ginger.Resource exposing
 
 # Definitions
 
-@docs Resource
 @docs ResourceWith
 
 @docs Edges

--- a/src/Ginger/Resource/Extra.elm
+++ b/src/Ginger/Resource/Extra.elm
@@ -62,7 +62,7 @@ authorName resource =
     in
     Maybe.andThen fromProperties <|
         List.head <|
-            Resource.edgesWithPredicate Predicate.HasAuthor resource
+            Resource.objectsOfPredicate Predicate.HasAuthor resource
 
 
 {-| -}

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -82,6 +82,7 @@ type Translation
 type alias Translations =
     { en : String
     , nl : String
+    , de : String
     , zh : String
     }
 
@@ -90,6 +91,7 @@ type alias Translations =
 type Language
     = EN
     | NL
+    | DE
     | ZH
 
 
@@ -101,6 +103,9 @@ languageAccessor language =
 
         NL ->
             .nl
+
+        DE ->
+            .de
 
         ZH ->
             .zh
@@ -115,6 +120,9 @@ languageModifier language =
         NL ->
             \value translations -> { translations | nl = value }
 
+        DE ->
+            \value translations -> { translations | de = value }
+
         ZH ->
             \value translations -> { translations | zh = value }
 
@@ -123,7 +131,7 @@ languageModifier language =
 -}
 empty : Translation
 empty =
-    Translation { en = "", nl = "", zh = "" }
+    Translation { en = "", nl = "", de = "", zh = "" }
 
 
 {-| Construct a Translation from a list of Language and String value pairs
@@ -132,7 +140,7 @@ fromList : List ( Language, String ) -> Translation
 fromList languageValuePairs =
     Translation <|
         List.foldl (\( language, value ) acc -> languageModifier language value acc)
-            { en = "", nl = "", zh = "" }
+            { en = "", nl = "", de = "", zh = "" }
             languageValuePairs
 
 
@@ -194,6 +202,9 @@ toIso639 language =
 
         NL ->
             "nl"
+
+        DE ->
+            "de"
 
         ZH ->
             "zh"
@@ -261,5 +272,6 @@ fromJson =
         (Decode.succeed Translations
             |> Pipeline.optional "en" Decode.string ""
             |> Pipeline.optional "nl" Decode.string ""
+            |> Pipeline.optional "de" Decode.string ""
             |> Pipeline.optional "zh" Decode.string ""
         )

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -10,6 +10,10 @@ module Ginger.Translation exposing
     , isEmpty
     , text
     , html
+    , textNL
+    , htmlNL
+    , textEN
+    , htmlEN
     , fromJson
     )
 
@@ -37,10 +41,18 @@ module Ginger.Translation exposing
 @docs isEmpty
 
 
-# Html
+# Render as Html
 
 @docs text
 @docs html
+
+
+# Render in language
+
+@docs textNL
+@docs htmlNL
+@docs textEN
+@docs htmlEN
 
 
 # Decode
@@ -208,6 +220,34 @@ text language translation =
 html : Language -> Translation -> List (Html msg)
 html language translation =
     Internal.Html.toHtml (toStringEscaped language translation)
+
+
+{-| Translate to Dutch and render as Html text
+-}
+textNL : Translation -> Html msg
+textNL =
+    text NL
+
+
+{-| Translate to Dutch and render as Html markup
+-}
+htmlNL : Translation -> List (Html msg)
+htmlNL =
+    html NL
+
+
+{-| Translate to English and render as Html text
+-}
+textEN : Translation -> Html msg
+textEN =
+    text EN
+
+
+{-| Translate to English and render as Html markup
+-}
+htmlEN : Translation -> List (Html msg)
+htmlEN =
+    html EN
 
 
 

--- a/src/Ginger/Translation.elm
+++ b/src/Ginger/Translation.elm
@@ -1,12 +1,13 @@
 module Ginger.Translation exposing
     ( Translation
     , Language(..)
+    , empty
+    , fromList
     , toString
     , toStringEscaped
     , withDefault
-    , isEmpty
-    , fromList
     , toIso639
+    , isEmpty
     , text
     , html
     , fromJson
@@ -21,14 +22,19 @@ module Ginger.Translation exposing
 @docs Language
 
 
-# Conversion
+# Construct
+
+@docs empty
+@docs fromList
+
+
+# Convert
 
 @docs toString
 @docs toStringEscaped
 @docs withDefault
-@docs isEmpty
-@docs fromList
 @docs toIso639
+@docs isEmpty
 
 
 # Html
@@ -101,6 +107,23 @@ languageModifier language =
             \value translations -> { translations | zh = value }
 
 
+{-| A Translation containing empty Strings
+-}
+empty : Translation
+empty =
+    Translation { en = "", nl = "", zh = "" }
+
+
+{-| Construct a Translation from a list of Language and String value pairs
+-}
+fromList : List ( Language, String ) -> Translation
+fromList languageValuePairs =
+    Translation <|
+        List.foldl (\( language, value ) acc -> languageModifier language value acc)
+            { en = "", nl = "", zh = "" }
+            languageValuePairs
+
+
 
 -- CONVERSIONS
 
@@ -147,16 +170,6 @@ withDefault def language translation =
 isEmpty : Language -> Translation -> Bool
 isEmpty language (Translation translation) =
     String.isEmpty (languageAccessor language translation)
-
-
-{-| Construct a Translation from a list of Language and String value pairs
--}
-fromList : List ( Language, String ) -> Translation
-fromList languageValuePairs =
-    Translation <|
-        List.foldl (\( language, value ) acc -> languageModifier language value acc)
-            { en = "", nl = "", zh = "" }
-            languageValuePairs
 
 
 {-| Convert a Language to an [Iso639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) String

--- a/src/Ginger/Util.elm
+++ b/src/Ginger/Util.elm
@@ -115,13 +115,6 @@ stripHtml =
     Internal.Html.stripHtml
 
 
-{-| Unescape character entity references
--}
-unescape : String -> List (Html msg)
-unescape =
-    Internal.Html.toHtml
-
-
 {-| Truncate a String and append `...` if the String is longer than provided length
 
 

--- a/src/Ginger/Util.elm
+++ b/src/Ginger/Util.elm
@@ -90,7 +90,7 @@ viewMaybe maybeA html1 =
 
 {-| Convert a String to Html
 
-_This unescapes html unicode characters as well_
+_This unescapes character entity references as well_
 
 -}
 toHtml : String -> List (Html msg)
@@ -106,13 +106,20 @@ toHtml =
 
     --> "Hola!"
 
-_This unescapes html unicode characters as well.
+_This unescapes character entity references as well.
 If parsing fails the original String is returned_
 
 -}
 stripHtml : String -> String
 stripHtml =
     Internal.Html.stripHtml
+
+
+{-| Unescape character entity references
+-}
+unescape : String -> List (Html msg)
+unescape =
+    Internal.Html.toHtml
 
 
 {-| Truncate a String and append `...` if the String is longer than provided length

--- a/src/Ginger/Util.elm
+++ b/src/Ginger/Util.elm
@@ -1,9 +1,7 @@
 module Ginger.Util exposing
     ( viewIf
     , viewIfNot
-    , viewEither
     , viewMaybe
-    , viewMaybeWithDefault
     , stripHtml
     , toHtml
     , truncate
@@ -16,13 +14,11 @@ module Ginger.Util exposing
 
 @docs viewIf
 @docs viewIfNot
-@docs viewEither
 
 
 # Optional views
 
 @docs viewMaybe
-@docs viewMaybeWithDefault
 
 
 # Parse Html
@@ -71,30 +67,6 @@ viewIfNot bool html1 =
     viewIf (not bool) html1
 
 
-{-| If the boolean expression evaluates to `True`, render some html, otherwise,
-render some other html.
-
-    view : Model -> Html msg
-    view model =
-        , article []
-            [ h1 [] [ text model.title ]
-            , p []
-                [ viewEither (model.category == Category.Article)
-                    (\_ -> text "article")
-                    (\_ -> text "something else")
-                ]
-            ]
-
--}
-viewEither : Bool -> (() -> Html msg) -> (() -> Html msg) -> Html msg
-viewEither bool html1 html2 =
-    if bool then
-        html1 ()
-
-    else
-        html2 ()
-
-
 {-| Maybe, the resource has an author. Render what's in the `maybe`, or nothing.
 
     view : Model -> Html msg
@@ -114,30 +86,6 @@ viewMaybe maybeA html1 =
 
         Nothing ->
             text ""
-
-
-{-| Render something else if there's nothing in the `maybe`.
-
-    view : Model -> Html msg
-    view model =
-        article []
-            [ h1 [] [ text "Article" ]
-            , p []
-                [ viewMaybeWithDefault model.author
-                    (\_ -> text "Anonymous")
-                    (\authorName -> text authorName)
-                ]
-            ]
-
--}
-viewMaybeWithDefault : Maybe a -> (() -> Html msg) -> (a -> Html msg) -> Html msg
-viewMaybeWithDefault maybeA default html1 =
-    case maybeA of
-        Just a ->
-            html1 a
-
-        Nothing ->
-            default ()
 
 
 {-| Convert a String to Html

--- a/src/Internal/Html.elm
+++ b/src/Internal/Html.elm
@@ -13,12 +13,12 @@ import Html.Parser.Util
 
 This unescapes character entity references as well
 
-_Defaults to empty List if parsing fails_
+_Will show an error if parsing fails_
 
 -}
 toHtml : String -> List (Html msg)
 toHtml s =
-    Result.withDefault [] <|
+    Result.withDefault [ text "Html could not be parsed" ] <|
         Result.map Html.Parser.Util.toVirtualDom <|
             Html.Parser.run s
 

--- a/src/Internal/Html.elm
+++ b/src/Internal/Html.elm
@@ -1,4 +1,8 @@
-module Internal.Html exposing (stripHtml, toHtml)
+module Internal.Html exposing
+    ( stripHtml
+    , toHtml
+    , unescape
+    )
 
 import Html exposing (..)
 import Html.Parser
@@ -7,22 +11,16 @@ import Html.Parser.Util
 
 {-| Convert a String to elm html
 
-This unescapes html unicode characters as well
+This unescapes character entity references as well
+
+_Defaults to empty List if parsing fails_
 
 -}
 toHtml : String -> List (Html msg)
 toHtml s =
-    let
-        parsedString =
-            Result.map Html.Parser.Util.toVirtualDom <|
-                Html.Parser.run s
-    in
-    case parsedString of
-        Err _ ->
-            [ Html.text "Html could not be parsed" ]
-
-        Ok ok ->
-            ok
+    Result.withDefault [] <|
+        Result.map Html.Parser.Util.toVirtualDom <|
+            Html.Parser.run s
 
 
 {-| A remove all html nodes from a String
@@ -34,7 +32,7 @@ toHtml s =
 
     --> "Hola!"
 
-This unescapes html unicode characters as well
+This unescapes character entity references as well
 
 -}
 stripHtml : String -> String
@@ -53,4 +51,16 @@ stripHtml s =
     in
     Result.withDefault s <|
         Result.map (List.foldr textNodes "") <|
+            Html.Parser.run s
+
+
+{-| Unescape character entity references
+
+_Defaults to original String if parsing fails_
+
+-}
+unescape : String -> String
+unescape s =
+    Result.withDefault s <|
+        Result.map (String.concat << List.map Html.Parser.nodeToString) <|
             Html.Parser.run s

--- a/src/Internal/Request.elm
+++ b/src/Internal/Request.elm
@@ -1,0 +1,139 @@
+module Internal.Request exposing
+    ( delete
+    , deleteTaskNoContent
+    , expectJson
+    , expectNoContent
+    , getTask
+    , postTask
+    , postTaskNoContent
+    , putTaskNoContent
+    )
+
+import Http
+import Json.Decode as Decode
+import Json.Encode as Encode
+import Task exposing (Task)
+
+
+
+-- REQUEST BUILDERS
+
+
+delete : String -> Http.Expect msg -> Cmd msg
+delete url expect =
+    Http.request
+        { method = "DELETE"
+        , headers = []
+        , url = url
+        , body = Http.emptyBody
+        , expect = expect
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+getTask : String -> Decode.Decoder a -> Task Http.Error a
+getTask url decoder =
+    Http.task
+        { method = "GET"
+        , headers = []
+        , url = url
+        , body = Http.emptyBody
+        , resolver = expectJson decoder
+        , timeout = Nothing
+        }
+
+
+postTask : String -> Http.Body -> Decode.Decoder a -> Task Http.Error a
+postTask url body decoder =
+    Http.task
+        { method = "POST"
+        , headers = []
+        , url = url
+        , body = body
+        , resolver = expectJson decoder
+        , timeout = Nothing
+        }
+
+
+postTaskNoContent : String -> Http.Body -> Task Http.Error ()
+postTaskNoContent url body =
+    Http.task
+        { method = "POST"
+        , headers = []
+        , url = url
+        , body = body
+        , resolver = expectNoContent
+        , timeout = Nothing
+        }
+
+
+putTaskNoContent : String -> Http.Body -> Task Http.Error ()
+putTaskNoContent url body =
+    Http.task
+        { method = "PUT"
+        , headers = []
+        , url = url
+        , body = body
+        , resolver = expectNoContent
+        , timeout = Nothing
+        }
+
+
+deleteTaskNoContent : String -> Task Http.Error ()
+deleteTaskNoContent url =
+    Http.task
+        { method = "DELETE"
+        , headers = []
+        , url = url
+        , body = Http.emptyBody
+        , resolver = expectNoContent
+        , timeout = Nothing
+        }
+
+
+expectNoContent : Http.Resolver Http.Error ()
+expectNoContent =
+    Http.stringResolver <|
+        \response ->
+            case response of
+                Http.BadUrl_ url ->
+                    Err (Http.BadUrl url)
+
+                Http.Timeout_ ->
+                    Err Http.Timeout
+
+                Http.NetworkError_ ->
+                    Err Http.NetworkError
+
+                Http.BadStatus_ metadata _ ->
+                    Err (Http.BadStatus metadata.statusCode)
+
+                Http.GoodStatus_ _ _ ->
+                    Ok ()
+
+
+expectJson : Decode.Decoder a -> Http.Resolver Http.Error a
+expectJson decoder =
+    Http.stringResolver <|
+        \response ->
+            case response of
+                Http.BadUrl_ url ->
+                    Err (Http.BadUrl url)
+
+                Http.Timeout_ ->
+                    Err Http.Timeout
+
+                Http.NetworkError_ ->
+                    Err Http.NetworkError
+
+                Http.BadStatus_ metadata _ ->
+                    Err (Http.BadStatus metadata.statusCode)
+
+                Http.GoodStatus_ _ body ->
+                    case Decode.decodeString decoder body of
+                        Ok value ->
+                            Ok value
+
+                        Err err ->
+                            Err (Http.BadBody (Decode.errorToString err))

--- a/tests/Extra.elm
+++ b/tests/Extra.elm
@@ -13,7 +13,7 @@ import Test.Html.Selector exposing (tag, text)
 
 suite : Test
 suite =
-    describe "The Ginger.Util module"
+    describe "The Ginger.Extra module"
         [ test "Renders a text as html" <|
             \_ ->
                 Html.article [] (Ginger.Util.toHtml "Hallo")
@@ -75,26 +75,6 @@ suite =
                         (\_ -> Html.text "I should not be rendered!")
                         |> Query.fromHtml
                         |> Query.hasNot [ text "I should not be rendered!" ]
-            , test "viewEither renders the first html option if boolean is True" <|
-                \() ->
-                    Ginger.Util.viewEither True
-                        (\_ -> Html.text "I am the first option!")
-                        (\_ -> Html.text "I am the second option!")
-                        |> Query.fromHtml
-                        |> Expect.all
-                            [ Query.has [ text "I am the first option!" ]
-                            , Query.hasNot [ text "I am the second option!" ]
-                            ]
-            , test "viewEither renders the second html option if boolean is False" <|
-                \() ->
-                    Ginger.Util.viewEither False
-                        (\_ -> Html.text "I am the first option!")
-                        (\_ -> Html.text "I am the second option!")
-                        |> Query.fromHtml
-                        |> Expect.all
-                            [ Query.hasNot [ text "I am the first option!" ]
-                            , Query.has [ text "I am the second option!" ]
-                            ]
             ]
         , describe "Optional views"
             [ test "viewMaybe renders nothing if there's nothing in the Maybe" <|
@@ -109,20 +89,6 @@ suite =
                         (\x -> Html.text (x ++ " should be rendered!"))
                         |> Query.fromHtml
                         |> Query.has [ text "Something should be rendered!" ]
-            , test "viewMaybeWithDefault renders something if there's something in the Maybe" <|
-                \() ->
-                    Ginger.Util.viewMaybeWithDefault (Just "Something")
-                        (\_ -> Html.text "I am the default text.")
-                        (\x -> Html.text (x ++ " should be rendered!"))
-                        |> Query.fromHtml
-                        |> Query.has [ text "Something should be rendered!" ]
-            , test "viewMaybeWithDefault renders the default html if there's nothing in the Maybe" <|
-                \() ->
-                    Ginger.Util.viewMaybeWithDefault Nothing
-                        (\_ -> Html.text "I am the default text.")
-                        (\x -> Html.text (x ++ " should not be rendered!"))
-                        |> Query.fromHtml
-                        |> Query.has [ text "I am the default text." ]
             ]
         , describe "String manipulation"
             [ test "truncates the string to provided length" <|

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -13,7 +13,11 @@ import Test.Html.Selector exposing (tag, text)
 suite : Test
 suite =
     describe "The Ginger Translation module"
-        [ test "Returns a translated string" <|
+        [ test "Returns an empty string" <|
+            \_ ->
+                Expect.equal "" <|
+                    Translation.toString EN Translation.empty
+        , test "Returns a translated string" <|
             \_ ->
                 Expect.equal "Hello" <|
                     Translation.toString EN translation

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -68,6 +68,26 @@ suite =
             \_ ->
                 Expect.false "Expected the String to not be empty" <|
                     Translation.isEmpty NL translation
+        , test "Renders a Dutch text as html" <|
+            \_ ->
+                Html.article [] [ Translation.textNL translation ]
+                    |> Query.fromHtml
+                    |> Query.has [ text "Hallo" ]
+        , test "Renders a English text as html" <|
+            \_ ->
+                Html.article [] [ Translation.textEN translation ]
+                    |> Query.fromHtml
+                    |> Query.has [ text "Hello" ]
+        , test "Renders a Dutch markup as html" <|
+            \_ ->
+                Html.article [] (Translation.htmlNL htmlTranslation)
+                    |> Query.fromHtml
+                    |> Query.has [ text "Hallo" ]
+        , test "Renders a English markup as html" <|
+            \_ ->
+                Html.article [] (Translation.htmlEN htmlTranslation)
+                    |> Query.fromHtml
+                    |> Query.has [ text "Hello" ]
         ]
 
 
@@ -96,6 +116,7 @@ htmlTranslation : Translation
 htmlTranslation =
     Translation.fromList
         [ ( NL, "<p>Hallo</p>" )
+        , ( EN, "<p>Hello</p>" )
         ]
 
 

--- a/tests/Translation.elm
+++ b/tests/Translation.elm
@@ -13,11 +13,7 @@ import Test.Html.Selector exposing (tag, text)
 suite : Test
 suite =
     describe "The Ginger Translation module"
-        [ test "Returns an empty string" <|
-            \_ ->
-                Expect.equal "" <|
-                    Translation.toString EN Translation.empty
-        , test "Returns a translated string" <|
+        [ test "Returns a translated string" <|
             \_ ->
                 Expect.equal "Hello" <|
                     Translation.toString EN translation


### PR DESCRIPTION
# v3.0.0
* Rename `category` -> `getCategory`
 * Rename `depiction` -> `getDepiction`
 * Rename `depictions` -> `getDepictions`
 * Rename `resourceQuery` -> `search`
 * Rename `locationQuery` -> `searchLocation`
 * Rename `Results` -> `SearchResult`
 * Add common REST API request
   * `deleteResource`
   * `postEdge`
   * `deleteEdge`
   * `uploadFile`
   * `uploadFileAndPostEdge`
 * Add `Request.HasContentGroup`
 * Add `Request.SearchType`
 * Add `Resource` alias for ResourceWith Edges
 * Add `Translation.DE`
 * Add `Ginger.Menu`
 * Add `Translation.empty`
 * Add `Translation.textNL`
 * Add `Translation.htmlNL`
 * Add `Translation.textEN`
 * Add `Translation.htmlEN`
 * Add `Id.toJson`
 * Rename edgesWithPredicate -> objectsOfPredicate
 * Use minimal constraint on objectsOfPredicate (`{ a | edges : List Edge }` instead of `ResourceWith Edges`)
 * Deprecate `viewEither` and `viewMaybeWithDefault`, use an `if` or `case` expression instead

Fix #16 